### PR TITLE
add pagination for table queries

### DIFF
--- a/src/browser/templates/query-browse-results.html
+++ b/src/browser/templates/query-browse-results.html
@@ -33,7 +33,7 @@
   {% endif %}
 {% endblock %}
 
-{% block pagenation %}
+{% block pagination %}
   <ul class="pagination pagination-sm">
     {% if pages|length > 1 %}
       {% if prev_page > 0 %}

--- a/src/browser/templates/table-browse-template.html
+++ b/src/browser/templates/table-browse-template.html
@@ -101,7 +101,7 @@
         <br />
         </div>
         <div class="inlineblock floatright">
-          {%block pagenation %}
+          {%block pagination %}
           {% endblock %}
         </div>
       {% endblock %}

--- a/src/browser/templates/table-browse-template.html
+++ b/src/browser/templates/table-browse-template.html
@@ -100,7 +100,12 @@
         </table>
         <br />
         </div>
+        <div class="inlineblock floatright">
+          {%block pagenation %}
+          {% endblock %}
+        </div>
       {% endblock %}
+
     {% else %}
       {% block table-empty-warning %}
       <p class="bg-warning">The <strong>{{table}}</strong> table is empty.</p>
@@ -228,6 +233,5 @@ $('.annotation-modal-dialog').on('click', function(e){
 
 {% block extra %}
 {% endblock %}
-
 
 {% endblock %}


### PR DESCRIPTION
Integrating datatables removed a pagination feature for queries. This restores that feature, and fixes david karger's table issue.

I'm hesitant to do more with this until we start refactoring the tempting system, slimming down views, and integrating data tables/hands on table for queries. There's a bunch of cruft here.