### PR TITLE
Add config for codeclimate.com.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,28 @@
+engines:
+  pep8:
+    enabled: true
+  radon:
+    enabled: true
+  fixme:
+    enabled: true
+    checks:
+      bug:
+        enabled: false
+ratings:
+  paths:
+  - "**.py"
+exclude_paths:
+- ".codeclimate.yml"
+- "conf.py"
+- "data/**/*"
+- "src/browser/static/docs/**/*"
+- "src/browser/static/lib/**/*"
+- "**/bootstrap.css"
+- "**/bootstrap.css.map"
+- "**/bootstrap-*.css.map"
+- "**/bootstrap.js"
+- "**/bootstrap-*.js"
+- "**/jquery.js"
+- "**/jquery-ui.js"
+- "**/d3.js"
+- "**/handlebars.js"


### PR DESCRIPTION
There's a bug in the csslint tool. This disables it so that CodeClimate can get to the rest of the project.

Once it is merged into master, https://codeclimate.com/github/datahuborg/datahub/ should work.