### PR TITLE
Tell CodeClimate to ignore thrift files and add badge to README.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -15,6 +15,7 @@ exclude_paths:
 - ".codeclimate.yml"
 - "conf.py"
 - "data/**/*"
+- "**/gen_*/**/*"
 - "src/browser/static/docs/**/*"
 - "src/browser/static/lib/**/*"
 - "**/bootstrap.css"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/datahuborg/datahub.svg?branch=master)](https://travis-ci.org/datahuborg/datahub)
+[![Build Status](https://travis-ci.org/datahuborg/datahub.svg?branch=master)](https://travis-ci.org/datahuborg/datahub) [![Code Climate](https://codeclimate.com/github/datahuborg/datahub/badges/gpa.svg)](https://codeclimate.com/github/datahuborg/datahub)
 
 *Note: This project is under development. It is not yet ready for production use.*
 


### PR DESCRIPTION
Ignoring gen_py, etc reduces the style issue count for the project from 3900 to 2225.