### PR TITLE
Use a prebuilt base Docker image to save build time.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,6 @@
-FROM ubuntu:14.04
-ENV PYTHONUNBUFFERED 1
-RUN apt-get update && apt-get install -y \
-        thrift-compiler \
-        python-pip \
-        python-dev \
-        libpq-dev \
-        libpq5 \
-        libffi-dev && \
-        apt-get clean
-RUN mkdir /datahub
-WORKDIR /datahub
+FROM datahuborg/datahub-base:0.1
 ADD requirements.txt /datahub/
+WORKDIR /datahub
 RUN pip install -r requirements.txt
 EXPOSE 8000
 ENV PYTHONPATH "/datahub/src:/datahub/src/gen-py:/datahub/src/apps"

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -1,0 +1,12 @@
+FROM ubuntu:14.04
+ENV PYTHONUNBUFFERED 1
+RUN apt-get update && apt-get install -y \
+        thrift-compiler \
+        python-pip \
+        python-dev \
+        libpq-dev \
+        libpq5 \
+        libffi-dev && \
+        apt-get clean
+ADD requirements.txt .
+RUN pip install -r requirements.txt

--- a/provisions/docker/build-images.sh
+++ b/provisions/docker/build-images.sh
@@ -15,6 +15,8 @@ docker build -t datahuborg/postgres provisions/postgres/
 echo "Building datahuborg/nginx (2/4)"
 docker build -t datahuborg/nginx provisions/nginx/
 echo "Building datahuborg/datahub (3/4)"
+# Build the base image manually if you can't pull from Docker Hub.
+# docker build -t datahuborg/datahub-base -f Dockerfile-base .
 docker build -t datahuborg/datahub .
 echo "Pulling latest phantomjs (4/4)"
 docker pull wernight/phantomjs:latest


### PR DESCRIPTION
The image includes apt-get and pip installs.