### PR TITLE
OAuth app management fixes

### DIFF
--- a/src/browser/views.py
+++ b/src/browser/views.py
@@ -848,6 +848,6 @@ class OAuthAppUpdate(ApplicationUpdate):
         # Make sure registrants can't disable the authorization step.
         # Only site admins can do that.
         original_object = get_application_model().objects.get(
-            name=form.instance.name)
+            pk=form.instance.pk)
         form.instance.skip_authorization = original_object.skip_authorization
         return super(OAuthAppUpdate, self).form_valid(form)

--- a/src/templates/oauth2_provider/application_detail.html
+++ b/src/templates/oauth2_provider/application_detail.html
@@ -39,17 +39,22 @@ $(document).ready(function() {
       </div>
       <div class="panel-body" style="word-wrap: break-word;">
         <p>
-          <label>Client id</label><br />
+          <label>App Name</label><br />
+          <span>{{ application.name }}</span>
+        </p>
+
+        <p>
+          <label>Client ID</label><br />
           <span>{{ application.client_id }}</span>
         </p>
 
         <p>
-          <label>Client secret</label><br />
+          <label>Client Secret</label><br />
           <span>{{ application.client_secret }}</span>
         </p>
 
         <p>
-          <label>Client type</label><br />
+          <label>Client Type</label><br />
           <span>{{ application.client_type }}</span>
         </p>
 


### PR DESCRIPTION
Show an OAuth app's name on its detail screen.

Allow OAuth apps to be renamed.