### PR TITLE
specify versions of swagger and django rest framework

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,8 +18,8 @@ python-social-auth==0.2.13
 pyjwkest==1.0.1
 django-crispy-forms==1.5.2
 factory_boy
-djangorestframework
-django-rest-swagger
+djangorestframework==3.3.3
+django-rest-swagger==0.3.5
 django-oauth-toolkit
 django-cors-headers
 django-rest-framework-social-oauth2


### PR DESCRIPTION
fixes travis builds. These were likely failing because of different versions of pip shipped with ubuntu's official vagrant branch and travis's