### PR TITLE
App permissions

### DIFF
--- a/src/account/utils.py
+++ b/src/account/utils.py
@@ -166,7 +166,8 @@ def grant_app_permission(username, repo_name, app_id, app_token):
         manager.add_collaborator(
             repo_name,
             app_id,
-            privileges=['SELECT', 'INSERT', 'UPDATE', 'DELETE'])
+            db_privileges=['SELECT', 'INSERT', 'UPDATE', 'DELETE'],
+            file_privileges=['read', 'write'])
         manager.close_connection()
     except Exception as e:
         raise e

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -260,8 +260,8 @@ OAUTH2_PROVIDER = {
     'ACCESS_TOKEN_EXPIRE_SECONDS': 24 * 60 * 60,
     # Authorization codes must be redeemed within 10 minutes.
     'AUTHORIZATION_CODE_EXPIRE_SECONDS': 600,
-    # Refresh tokens are good for 2 weeks.
-    'REFRESH_TOKEN_EXPIRE_SECONDS': 14 * 24 * 60 * 60,
+    # Refresh tokens never expire. Users can still manually revoke tokens.
+    'REFRESH_TOKEN_EXPIRE_SECONDS': None,
     'REQUEST_APPROVAL_PROMPT': 'force',
     'OAUTH2_BACKEND_CLASS':
         'api.oauth2_backends.ContentNegotiatingOAuthLibCore',


### PR DESCRIPTION
Makes granting permissions to a Thrift app work again.

Makes refresh tokens never expire. Users can still revoke them manually from their settings page.