### PR TITLE
grant create privilege to collaborator

### DIFF
--- a/src/browser/templates/repo-settings.html
+++ b/src/browser/templates/repo-settings.html
@@ -83,6 +83,11 @@
                                 <input type="checkbox" name="db_privileges" value="TRIGGER" checked/> trigger
                             </label>
                         </div>
+                        <div class="checkbox">
+                            <label title="Allows ability to create tables in the repo.">
+                                <input type="checkbox" name="db_privileges" value="CREATE" checked/> create
+                            </label>
+                        </div>
                         <p class="help-block">Permissions for repo files:</p>
                         <div class="checkbox">
                             <label title="Allows read access to files and cards in the repo">

--- a/src/core/db/backend/pg.py
+++ b/src/core/db/backend/pg.py
@@ -208,6 +208,12 @@ class PGBackend:
         for privilege in db_privileges:
             self._check_for_injections(privilege)
 
+        grantCreatePrivilege = False
+        if 'CREATE' in db_privileges:
+            grantCreatePrivilege = True
+            db_privileges.remove('CREATE')
+
+
         query = ('BEGIN;'
                  'GRANT USAGE ON SCHEMA %s TO %s;'
                  'GRANT %s ON ALL TABLES IN SCHEMA %s TO %s;'
@@ -221,6 +227,15 @@ class PGBackend:
                   collaborator, repo, privileges_str, collaborator]
         params = tuple(map(lambda x: AsIs(x), params))
         res = self.execute_sql(query, params)
+
+        query = ('BEGIN;'
+                 'GRANT CREATE ON SCHEMA %s TO %s;'
+                 'COMMIT;'
+                 )
+        params = [repo, collaborator]
+        params = tuple(map(lambda x: AsIs(x), params))
+        res = self.execute_sql(query, params)
+
         return res['status']
 
     def delete_collaborator(self, repo, collaborator):

--- a/src/core/db/manager.py
+++ b/src/core/db/manager.py
@@ -395,7 +395,7 @@ class DataHubManager:
 
         invalid_db_privileges = set(db_privileges) - {
             'SELECT', 'INSERT', 'UPDATE', 'DELETE',
-            'TRUNCATE', 'REFERENCES', 'TRIGGER'}
+            'TRUNCATE', 'REFERENCES', 'TRIGGER', 'CREATE'}
         if len(invalid_db_privileges) > 0:
             raise ValueError(
                 "Unsupported db privileges: \"{0}\"".format(


### PR DESCRIPTION
Grant create privilege works, but if a collaborator creates a table in another user's repository, only the collaborator can see / select that specific table.
