### PR TITLE
Make API export methods accept a desired file name

### DIFF
--- a/src/api/serializer.py
+++ b/src/api/serializer.py
@@ -265,11 +265,12 @@ class TableSerializer(DataHubSerializer):
         success = self.manager.delete_table(repo, table, force)
         return success
 
-    def export_table(self, repo, table, file_format='CSV', delimiter=',',
-                     header=True):
+    def export_table(self, repo, table, file_name=None, file_format='CSV',
+                     delimiter=',', header=True):
+        file_name = file_name or table
         self.manager.export_table(
-            repo=repo, table=table, file_format=file_format,
-            delimiter=delimiter, header=header)
+            repo=repo, table=table, file_name=file_name,
+            file_format=file_format, delimiter=delimiter, header=header)
 
 
 class ViewSerializer(DataHubSerializer):
@@ -308,10 +309,11 @@ class ViewSerializer(DataHubSerializer):
         success = self.manager.delete_view(repo, view, force)
         return success
 
-    def export_view(self, repo, view, file_format='CSV', delimiter=',',
-                    header=True):
+    def export_view(self, repo, view, file_name=None, file_format='CSV',
+                    delimiter=',', header=True):
+        file_name = file_name or view
         self.manager.export_view(
-            repo=repo, view=view, file_format=file_format,
+            repo=repo, view=view, file_name=file_name, file_format=file_format,
             delimiter=delimiter, header=header)
 
 
@@ -375,8 +377,9 @@ class CardSerializer(DataHubSerializer):
     def delete_card(self, repo, card_name):
         return self.manager.delete_card(repo, card_name)
 
-    def export_card(self, repo, card_name, file_format='CSV'):
-        self.manager.export_card(repo, card_name, file_format)
+    def export_card(self, repo, card_name, file_name=None, file_format='CSV'):
+        file_name = file_name or card_name
+        self.manager.export_card(repo, card_name, file_name, file_format)
 
 
 class FileSerializer(DataHubSerializer):

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -413,6 +413,9 @@ class Files(APIView):
         omit_serializer: true
 
         parameters:
+          - name: file_name
+            in: body
+            type: string
           - name: file_format
             in: body
             type: string
@@ -450,6 +453,9 @@ class Files(APIView):
         table = data.get('from_table', None)
         view = data.get('from_view', None)
         card = data.get('from_card', None)
+        # file_name should default to the name of the table
+        file_name = data.get('file_name',
+                             next((i for i in [table, view, card] if i), None))
 
         if file:
             serializer = FileSerializer(username, repo_base, request)
@@ -459,28 +465,28 @@ class Files(APIView):
 
         elif table:
             serializer = TableSerializer(username, repo_base, request)
-            serializer.export_table(repo_name, table, file_format, delimiter,
-                                    header)
+            serializer.export_table(repo_name, table, file_name, file_format,
+                                    delimiter, header)
 
-            filename = table + "." + file_format
+            filename = file_name + "." + file_format
             serializer = FileSerializer(username, repo_base, request)
             file = serializer.get_file(repo_name, filename)
             return Response(file, status=status.HTTP_201_CREATED)
 
         elif view:
             serializer = ViewSerializer(username, repo_base, request)
-            serializer.export_view(repo_name, view, file_format, delimiter,
-                                   header)
-            filename = view + "." + file_format
+            serializer.export_view(repo_name, view, file_name, file_format,
+                                   delimiter, header)
+            filename = file_name + "." + file_format
             serializer = FileSerializer(username, repo_base, request)
             file = serializer.get_file(repo_name, filename)
             return Response(file, status=status.HTTP_201_CREATED)
 
         elif card:
             serializer = CardSerializer(username, repo_base, request)
-            serializer.export_card(repo_name, card, file_format)
+            serializer.export_card(repo_name, card, file_name, file_format)
 
-            filename = card + "." + file_format
+            filename = file_name + "." + file_format
             serializer = FileSerializer(username, repo_base, request)
             file = serializer.get_file(repo_name, filename)
             return Response(file, status=status.HTTP_201_CREATED)

--- a/src/core/db/connection.py
+++ b/src/core/db/connection.py
@@ -163,7 +163,8 @@ class DataHubConnection:
             table_name=table_name,
             file_path=file_path,
             file_format=file_format,
-            delimiter=delimiter)
+            delimiter=delimiter,
+            header=header)
 
     def export_view(self, view_name, file_path, file_format='CSV',
                     delimiter=',', header=True):
@@ -171,7 +172,8 @@ class DataHubConnection:
             view_name=view_name,
             file_path=file_path,
             file_format=file_format,
-            delimiter=delimiter)
+            delimiter=delimiter,
+            header=header)
 
     def export_query(self, query, file_path, file_format='CSV',
                      delimiter=',', header=True):
@@ -179,7 +181,8 @@ class DataHubConnection:
             query=query,
             file_path=file_path,
             file_format=file_format,
-            delimiter=delimiter)
+            delimiter=delimiter,
+            header=header)
 
     def list_collaborators(self, repo):
         return self.backend.list_collaborators(repo)


### PR DESCRIPTION
export_table, export_view, and export_card via the REST API previously never worked. The expected file_name was never passed to the manager.py methods.

Now those parameters have default values and API callers can specify a file_name.